### PR TITLE
updating PROTOCOL_SSL version

### DIFF
--- a/xssya.py
+++ b/xssya.py
@@ -65,7 +65,7 @@ myopener = MyOpener()
 
 
 class fake_ssl:
-    wrap_socket = partial(ssl.wrap_socket, ssl_version=ssl.PROTOCOL_SSLv3)
+    wrap_socket = partial(ssl.wrap_socket, ssl_version=ssl.PROTOCOL_SSLv23)
 
 httplib.ssl = fake_ssl
 


### PR DESCRIPTION
fixing this bug: 
```
Traceback (most recent call last):
  File "./xssya.py", line 67, in <module>
    class fake_ssl:
  File "./xssya.py", line 68, in fake_ssl
    wrap_socket = partial(ssl.wrap_socket, ssl_version=ssl.PROTOCOL_SSLv3)
AttributeError: 'module' object has no attribute 'PROTOCOL_SSLv3'
```
as told [here](https://docs.python.org/2/library/ssl.html#ssl.get_server_certificate) : default ssl_version is changed from PROTOCOL_SSLv3 to PROTOCOL_SSLv23 for maximum compatibility with modern servers.